### PR TITLE
Enforce lowercase name of imported features and matches

### DIFF
--- a/import_features.py
+++ b/import_features.py
@@ -241,10 +241,10 @@ def import_features(cfg, data_list):
             # copy match file to raw results folder
 
             if os.path.isfile(fn_multiview_match) and os.path.isfile(fn_stereo_match_list[0]):
-                print('------ Multiview match file and Stereo match file are provieded seperately')
+                print('------ Multiview match file and Stereo match file are provided seperately')
                 fn_match = fn_multiview_match
             else:
-                print('------ Only one match file is provided for both stereo and multiveiw tasks')
+                print('------ Only one match file is provided for both stereo and multiview tasks')
 
             copy(fn_match,os.path.join(match_folder_path,'matches.h5'))
             # make dummy cost file
@@ -315,10 +315,11 @@ def import_features(cfg, data_list):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--matches_key_reverse',
-                        action='store_true',
-                        default=False,
-                        help='reverse the image name position in match keys')
+    parser.add_argument(
+        '--matches_key_reverse',
+        action='store_true',
+        default=False,
+        help='reverse the image name position in match keys')
     parser.add_argument(
         '--kp_name',
         type=str,
@@ -340,13 +341,15 @@ if __name__ == '__main__':
         type=int,
         default=-1,
         help='Number of keypoints (-1 to use all)')
-    parser.add_argument('--path_features',
-                        type=str,
-                        help='Path to the features to import')
-    parser.add_argument('--path_results',
-                        type=str,
-                        default='../benchmark-results/phototourism/',
-                        help='Directory holding benchmark results.')
+    parser.add_argument(
+        '--path_features',
+        type=str,
+        help='Path to the features to import')
+    parser.add_argument(
+        '--path_results',
+        type=str,
+        default='../benchmark-results/phototourism/',
+        help='Directory holding benchmark results.')
     parser.add_argument(
         '--subset',
         type=str,

--- a/import_features.py
+++ b/import_features.py
@@ -63,7 +63,7 @@ def get_descriptor_nbytes(cfg, data_list):
 def validate_label(label):
     if '_' in label:
         print('WARNING: Replacing underscore with hyphen in method name')
-    return label.replace('_', '-')
+    return label.replace('_', '-').lower()
 
 
 def import_features(cfg, data_list):
@@ -100,7 +100,7 @@ def import_features(cfg, data_list):
         numkp = cfg.num_keypoints
         print('Pre-selected number of keypoints: {}'.format(numkp))
 
-    # only check descriptor size if it is provided    
+    # only check descriptor size if it is provided
     if os.path.isfile(os.path.join(cfg.path_features, data_list[0], 'descriptors.h5')):
         # Open a descriptors file to get their size
         print('Retrieving descriptor_size...')
@@ -140,7 +140,7 @@ def import_features(cfg, data_list):
             '_'.join([cfg.kp_name, str(numkp), cfg.desc_name]))
         if not os.path.isdir(tgt_cur):
             os.makedirs(tgt_cur)
-            
+
         # Both keypoints and descriptors files are provided
         if os.path.isfile(fn_kp) and os.path.isfile(fn_desc) and not \
            (os.path.isfile(fn_match) or (
@@ -219,7 +219,7 @@ def import_features(cfg, data_list):
             if numkp < max(size_kp_file):
                 raise RuntimeError('------ number of keypoints exceeds maximum allowed limit'
                                    '(wanted: {}, found: {})'.format(
-                                       numkp, max(size_kp_file)))   
+                                       numkp, max(size_kp_file)))
 
             # copy keypoints file to raw results folder
             copy(fn_kp, tgt_cur)
@@ -260,7 +260,7 @@ def import_features(cfg, data_list):
             # make dummy cost file
             with h5py.File(os.path.join(filter_folder_path,'matches_inlier_cost.h5'),'w') as h5_w:
                 h5_w.create_dataset('cost', data=0.0)
-            
+
             # check if three stereo matches are provided
             if all([os.path.isfile(fn_stereo_match_list[idx]) for idx in range(3)]):
                 print('------ Three stereo match files are provided')
@@ -319,19 +319,22 @@ if __name__ == '__main__':
                         action='store_true',
                         default=False,
                         help='reverse the image name position in match keys')
-    parser.add_argument('--kp_name',
-                        type=str,
-                        default='',
-                        help='Name of the method used to extract keypoints')
-    parser.add_argument('--desc_name',
-                        type=str,
-                        default='',
-                        help='Name of the method used to extract descriptors')
+    parser.add_argument(
+        '--kp_name',
+        type=str,
+        default='',
+        help='Name of the method used to extract keypoints, lower case only')
+    parser.add_argument(
+        '--desc_name',
+        type=str,
+        default='',
+        help='Name of the method used to extract descriptors, lower case only')
     parser.add_argument(
         '--match_name',
         type=str,
         default='',
-        help='Name of the method used to match features, if any')
+        help='Name of the method used to match features, if any, '
+        'lower case only')
     parser.add_argument(
         '--num_keypoints',
         type=int,


### PR DESCRIPTION
- force the names of imported keypoints, descriptors, and matches to be lower case
- fix typos and style inconsistencies in `import_features.py`