### PR TITLE
Feature/pairwise matching

### DIFF
--- a/compute_match.py
+++ b/compute_match.py
@@ -92,7 +92,7 @@ def main(cfg):
     # Feature Matching
     print('Computing matches')
     num_cores = cfg.num_opencv_threads if cfg.num_opencv_threads > 0 else int(
-        len(os.sched_getaffinity(0)) * 0.9)
+        len(os.sched_getaffinity(0)) * 0.75)
     if WITH_FAISS:
         num_cores = min(4, num_cores)
     result = Parallel(n_jobs=num_cores)(

--- a/compute_model.py
+++ b/compute_model.py
@@ -106,7 +106,10 @@ def main(cfg):
     if os.path.exists(get_geom_file(cfg)):
         print(' -- already exists, skipping model computation')
         return
-
+    try:
+        pairwise_keypoints = cfg.method_dict['config_common']['pairwise_keypoints']
+    except:
+        pairwise_keypoints = False
     # Get data directory
     keypoints_dict = load_h5(get_kp_file(cfg))
 
@@ -160,11 +163,11 @@ def main(cfg):
         scale_dict = defaultdict(list)
 
     random.shuffle(pairs_per_th['0.0'])
-    if cfg.pairwise_keypoints: # picks keypoints per pair
+    if pairwise_keypoints: # picks keypoints per pair
         result = Parallel(n_jobs=num_cores)(delayed(compute_model)(
             cfg, np.asarray(matches_dict[pair]),
             np.asarray(keypoints_dict[pair.split('-')[0]+'-'+pair.split('-')[1]]),
-            np.asarray(keypoints_dict[pair.split('-')[1]+'-'+pair.split('-')[0]]]),
+            np.asarray(keypoints_dict[pair.split('-')[1]+'-'+pair.split('-')[0]]),
             calib_dict[pair.split(
                 '-')[0]], calib_dict[pair.split('-')[1]], images_list[
                     image_names.index(pair.split('-')[0])], images_list[

--- a/compute_model.py
+++ b/compute_model.py
@@ -135,7 +135,7 @@ def main(cfg):
     except Exception:
         desc_dict = defaultdict(list)
 
-    
+
     try:
         aff_dict = defaultdict(list)
         aff_dict1 = load_h5(get_affine_file(cfg))
@@ -160,22 +160,41 @@ def main(cfg):
         scale_dict = defaultdict(list)
 
     random.shuffle(pairs_per_th['0.0'])
-    result = Parallel(n_jobs=num_cores)(delayed(compute_model)(
-        cfg, np.asarray(matches_dict[pair]),
-        np.asarray(keypoints_dict[pair.split('-')[0]]),
-        np.asarray(keypoints_dict[pair.split('-')[1]]), calib_dict[pair.split(
-            '-')[0]], calib_dict[pair.split('-')[1]], images_list[
-                image_names.index(pair.split('-')[0])], images_list[
-                    image_names.index(pair.split('-')[1])],
-        np.asarray(scale_dict[pair.split('-')[0]]),
-        np.asarray(scale_dict[pair.split('-')[1]]),
-        np.asarray(ori_dict[pair.split('-')[0]]),
-        np.asarray(ori_dict[pair.split('-')[1]]),
-        np.asarray(aff_dict[pair.split('-')[0]]),
-        np.asarray(aff_dict[pair.split('-')[1]]),
-        np.asarray(desc_dict[pair.split('-')[0]]),
-        np.asarray(desc_dict[pair.split('-')[1]]))
-                                        for pair in tqdm(pairs_per_th['0.0']))
+    if cfg.pairwise_keypoints: # picks keypoints per pair
+        result = Parallel(n_jobs=num_cores)(delayed(compute_model)(
+            cfg, np.asarray(matches_dict[pair]),
+            np.asarray(keypoints_dict[pair.split('-')[0]+'-'+pair.split('-')[1]]),
+            np.asarray(keypoints_dict[pair.split('-')[1]+'-'+pair.split('-')[0]]]),
+            calib_dict[pair.split(
+                '-')[0]], calib_dict[pair.split('-')[1]], images_list[
+                    image_names.index(pair.split('-')[0])], images_list[
+                        image_names.index(pair.split('-')[1])],
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None)
+                                            for pair in tqdm(pairs_per_th['0.0']))
+    else:
+        result = Parallel(n_jobs=num_cores)(delayed(compute_model)(
+            cfg, np.asarray(matches_dict[pair]),
+            np.asarray(keypoints_dict[pair.split('-')[0]]),
+            np.asarray(keypoints_dict[pair.split('-')[1]]), calib_dict[pair.split(
+                '-')[0]], calib_dict[pair.split('-')[1]], images_list[
+                    image_names.index(pair.split('-')[0])], images_list[
+                        image_names.index(pair.split('-')[1])],
+            np.asarray(scale_dict[pair.split('-')[0]]),
+            np.asarray(scale_dict[pair.split('-')[1]]),
+            np.asarray(ori_dict[pair.split('-')[0]]),
+            np.asarray(ori_dict[pair.split('-')[1]]),
+            np.asarray(aff_dict[pair.split('-')[0]]),
+            np.asarray(aff_dict[pair.split('-')[1]]),
+            np.asarray(desc_dict[pair.split('-')[0]]),
+            np.asarray(desc_dict[pair.split('-')[1]]))
+                                            for pair in tqdm(pairs_per_th['0.0']))
     # Make model dictionary
     model_dict = {}
     inl_dict = {}

--- a/compute_stereo.py
+++ b/compute_stereo.py
@@ -90,19 +90,33 @@ def main(cfg):
     print('Compute stereo metrics for all pairs')
     #num_cores = int(multiprocessing.cpu_count() * 0.9)
     num_cores = int(len(os.sched_getaffinity(0)) * 0.9)
-
-    result = Parallel(n_jobs=num_cores)(delayed(compute_stereo_metrics_from_E)(
-        images_list[image_names.index(pair.split('-')[0])], images_list[
-            image_names.index(pair.split('-')[1])],
-        depth_maps_list[image_names.index(pair.split('-')[0])] if cfg.
-        dataset != 'googleurban' else None, depth_maps_list[image_names.index(
-            pair.split('-')[1])] if cfg.dataset != 'googleurban' else None,
-        np.asarray(keypoints_dict[pair.split('-')[0]]),
-        np.asarray(keypoints_dict[pair.split('-')[1]]), calib_dict[pair.split(
-            '-')[0]], calib_dict[pair.split('-')
-                                 [1]], geom_dict[pair], matches_dict[pair],
-        filter_matches_dict[pair], geom_inl_dict[pair], cfg)
-                                        for pair in tqdm(pairs_per_th['0.0']))
+    if cfg.pairwise_keypoints: # picks keypoints per pair
+        result = Parallel(n_jobs=num_cores)(delayed(compute_stereo_metrics_from_E)(
+            images_list[image_names.index(pair.split('-')[0])], images_list[
+                image_names.index(pair.split('-')[1])],
+            depth_maps_list[image_names.index(pair.split('-')[0])] if cfg.
+            dataset != 'googleurban' else None, depth_maps_list[image_names.index(
+                pair.split('-')[1])] if cfg.dataset != 'googleurban' else None,
+            np.asarray(keypoints_dict[pair.split('-')[0]+'-'+pair.split('-')[1]]),
+            np.asarray(keypoints_dict[pair.split('-')[1]+'-'+pair.split('-')[0]]]),
+            calib_dict[pair.split(
+                '-')[0]], calib_dict[pair.split('-')
+                                     [1]], geom_dict[pair], matches_dict[pair],
+            filter_matches_dict[pair], geom_inl_dict[pair], cfg)
+                                            for pair in tqdm(pairs_per_th['0.0']))
+    else:
+        result = Parallel(n_jobs=num_cores)(delayed(compute_stereo_metrics_from_E)(
+            images_list[image_names.index(pair.split('-')[0])], images_list[
+                image_names.index(pair.split('-')[1])],
+            depth_maps_list[image_names.index(pair.split('-')[0])] if cfg.
+            dataset != 'googleurban' else None, depth_maps_list[image_names.index(
+                pair.split('-')[1])] if cfg.dataset != 'googleurban' else None,
+            np.asarray(keypoints_dict[pair.split('-')[0]]),
+            np.asarray(keypoints_dict[pair.split('-')[1]]), calib_dict[pair.split(
+                '-')[0]], calib_dict[pair.split('-')
+                                     [1]], geom_dict[pair], matches_dict[pair],
+            filter_matches_dict[pair], geom_inl_dict[pair], cfg)
+                                            for pair in tqdm(pairs_per_th['0.0']))
 
     # Convert previous visibility list to strings
     old_keys = []

--- a/compute_stereo.py
+++ b/compute_stereo.py
@@ -49,6 +49,10 @@ def main(cfg):
 
     # Get data directory
     data_dir = get_data_path(cfg)
+    try:
+        pairwise_keypoints = cfg.method_dict['config_common']['pairwise_keypoints']
+    except:
+        pairwise_keypoints = False
 
     # Load pre-computed pairs with the new visibility criteria
     pairs_per_th = get_pairs_per_threshold(data_dir)
@@ -90,7 +94,7 @@ def main(cfg):
     print('Compute stereo metrics for all pairs')
     #num_cores = int(multiprocessing.cpu_count() * 0.9)
     num_cores = int(len(os.sched_getaffinity(0)) * 0.9)
-    if cfg.pairwise_keypoints: # picks keypoints per pair
+    if pairwise_keypoints: # picks keypoints per pair
         result = Parallel(n_jobs=num_cores)(delayed(compute_stereo_metrics_from_E)(
             images_list[image_names.index(pair.split('-')[0])], images_list[
                 image_names.index(pair.split('-')[1])],
@@ -98,7 +102,7 @@ def main(cfg):
             dataset != 'googleurban' else None, depth_maps_list[image_names.index(
                 pair.split('-')[1])] if cfg.dataset != 'googleurban' else None,
             np.asarray(keypoints_dict[pair.split('-')[0]+'-'+pair.split('-')[1]]),
-            np.asarray(keypoints_dict[pair.split('-')[1]+'-'+pair.split('-')[0]]]),
+            np.asarray(keypoints_dict[pair.split('-')[1]+'-'+pair.split('-')[0]]),
             calib_dict[pair.split(
                 '-')[0]], calib_dict[pair.split('-')
                                      [1]], geom_dict[pair], matches_dict[pair],
@@ -183,7 +187,7 @@ def main(cfg):
                     err_q = result[i][2]
                     err_t = result[i][3]
                     _rep_s_dict[
-                        all_keys[i]] = result[i][4] if result[i][4] else None
+                        all_keys[i]] = result[i][4] if result[i][4] else []#None
                     _err_dict[all_keys[i]] = [err_q, err_t]
         geo_s_dict_pre_match_th[th] = _geo_s_dict_pre_match
         geo_s_dict_refined_match_th[th] = _geo_s_dict_refined_match

--- a/config.py
+++ b/config.py
@@ -416,7 +416,7 @@ def validate_method(method, is_challenge, datasets):
             'keypoint': And(Use(str), lambda v: re.match("^[a-z0-9-.]*$", v)),
             'descriptor': And(Use(str),
                               lambda v: re.match("^[a-z0-9-.]*$", v)),
-            'num_keypoints': And(int, lambda v: v > 1),
+            'num_keypoints': And(int, lambda v: v > 1 or v == -1),
         },
         **possible_ds,
     })
@@ -522,11 +522,11 @@ def validate_method(method, is_challenge, datasets):
                         raise ValueError(
                             '[{}/stereo] custom match submission can only use cv2-8pt'
                             .format(dataset1)
-                        )                       
+                        )
 
                 # Threshold for RANSAC
                 if geom['method'].lower() in [
-                        'cv2-ransac-f', 'cv2-ransac-e', 
+                        'cv2-ransac-f', 'cv2-ransac-e',
                     'cv2-usacdef-f',
                     'cv2-usacmagsac-f',
                     'cv2-usacfast-f',

--- a/config.py
+++ b/config.py
@@ -417,6 +417,7 @@ def validate_method(method, is_challenge, datasets):
             'descriptor': And(Use(str),
                               lambda v: re.match("^[a-z0-9-.]*$", v)),
             'num_keypoints': And(int, lambda v: v > 1 or v == -1),
+            Optional('pairwise_keypoints'):  bool,
         },
         **possible_ds,
     })

--- a/config.py
+++ b/config.py
@@ -318,7 +318,7 @@ def validate_method(method, is_challenge):
             'json_label': str,
             'keypoint': And(Use(str), lambda v: '_' not in v),
             'descriptor': And(Use(str), lambda v: '_' not in v),
-            'num_keypoints': And(int, lambda v: v > 1),
+            'num_keypoints': And(int, lambda v: v > 1 or v == -1),
         },
         Optional('config_phototourism_stereo'): {
             Optional('use_custom_matches'): bool,

--- a/import_features.py
+++ b/import_features.py
@@ -91,8 +91,12 @@ def import_features(cfg, data_list):
                                                      np.max(size_kp_file),
                                                      np.mean(size_kp_file)))
 
+    # Set number of kp to a large number for pairwise matching
+    if cfg.pairwise_matching:
+        numkp = 1000000
+        print('Pairwise matching mode, no limit on kp')
     # If no category is selected, determine it automatically
-    if cfg.num_keypoints == -1:
+    elif cfg.num_keypoints == -1:
         numkp = get_kp_category(np.max(size_kp_file))
         print('Setting number of keypoints category to: {}'.format(numkp))
     # Otherwise, hand-pick it
@@ -135,9 +139,14 @@ def import_features(cfg, data_list):
             format(idx) for idx in range(3)]
 
         # create keypoints folder
-        tgt_cur = os.path.join(
-            cfg.path_results, _data,
-            '_'.join([cfg.kp_name, str(numkp), cfg.desc_name]))
+        if cfg.pairwise_matching:
+            tgt_cur = os.path.join(
+                cfg.path_results, _data,
+                '_'.join([cfg.kp_name, str(-1), cfg.desc_name]))
+        else:
+            tgt_cur = os.path.join(
+                cfg.path_results, _data,
+                '_'.join([cfg.kp_name, str(numkp), cfg.desc_name]))
         if not os.path.isdir(tgt_cur):
             os.makedirs(tgt_cur)
 
@@ -342,6 +351,11 @@ if __name__ == '__main__':
         default=-1,
         help='Number of keypoints (-1 to use all)')
     parser.add_argument(
+        '--pairwise_matching',
+        default=False, 
+        action='store_true',
+        help='Enable for pairwise matching methods')
+    parser.add_argument(
         '--path_features',
         type=str,
         help='Path to the features to import')
@@ -363,7 +377,7 @@ if __name__ == '__main__':
 
     if not cfg.kp_name:
         raise RuntimeError('Must define kp_name')
-    if not cfg.desc_name:
+    if not cfg.desc_name and not cfg.pairwise_matching:
         raise RuntimeError('Must define desc_name')
     if cfg.match_name and cfg.num_keypoints != -1:
         raise RuntimeError('Can not crop keypoints list with a custom matcher')

--- a/methods/geom_models/geom_cmp.py
+++ b/methods/geom_models/geom_cmp.py
@@ -17,7 +17,7 @@ import numpy as np
 import math
 
 try:
-    import pyransac
+    import pydegensac as pyransac
 except Exception:
     print('WARNING: Could not import pyransac')
     pass

--- a/utils/pack_helper.py
+++ b/utils/pack_helper.py
@@ -229,9 +229,12 @@ def compute_repeatability(res_dict, deprecated_images, cfg):
             get_repeatability_score_file(cfg, th) ,deprecated_images)
 
         for key, values in repeatability_dict.items():
-            # Simply return average of all pairs
-            for idx in range(len(px_th_list)):
-                ms_list_list[idx] += [values[idx]]
+            if len(values) == 0:
+                continue
+            else:
+                # Simply return average of all pairs
+                for idx in range(len(px_th_list)):
+                    ms_list_list[idx] += [values[idx]]
 
         # Now compute average number of keypoints
         acc = []

--- a/utils/pack_helper.py
+++ b/utils/pack_helper.py
@@ -233,12 +233,21 @@ def compute_repeatability(res_dict, deprecated_images, cfg):
             get_repeatability_score_file(cfg, th), deprecated_images)
 
         for key, values in repeatability_dict.items():
+<<<<<<< HEAD
             # Simply return average of all pairs
             for idx in range(len(px_th_list)):
                 try:
                     ms_list_list[idx] += [values[idx]]
                 except:
                     print("Warning")
+=======
+            if len(values) == 0:
+                continue
+            else:
+                # Simply return average of all pairs
+                for idx in range(len(px_th_list)):
+                    ms_list_list[idx] += [values[idx]]
+>>>>>>> 2e9fa62 (fix bug for packing empty repeatability list)
 
         # Now compute average number of keypoints
         acc = []

--- a/utils/queue_helper.py
+++ b/utils/queue_helper.py
@@ -237,8 +237,11 @@ def queue_job(job_file_fullpath, cfg, num_queue=1, dep_str=None, cpu=None):
             com += [job_file_fullpath]
             # Queue the job
             print(' '.join(com))
-            slurm_res = subprocess.run(com, stdout=subprocess.PIPE)
-            print(slurm_res.stdout.decode().rstrip('\n'))
+            for i in range(3):
+                slurm_res = subprocess.run(com, stdout=subprocess.PIPE)
+                print(slurm_res.stdout.decode().rstrip('\n'))
+                if slurm_res.returncode == 0:
+                    break
             # Get job ID
             if slurm_res.returncode != 0:
                 raise RuntimeError('Slurm error!')

--- a/utils/stereo_helper.py
+++ b/utils/stereo_helper.py
@@ -279,14 +279,18 @@ def compute_stereo_metrics_from_E(img1, img2, depth1, depth2, kp1, kp2, calib1,
 
     # Calculate repeatability
     # Thresholds are hardcoded
-    rep_s_list_1 = get_repeatability(
-        kp1_p[np.intersect1d(kp1_p_valid_idx, d1_nonzero_idx)], kp2,
-        cfg.matching_score_and_repeatability_px_threshold)
-    rep_s_list_2 = get_repeatability(
-        kp2_p[np.intersect1d(kp2_p_valid_idx, d2_nonzero_idx)], kp1,
-        cfg.matching_score_and_repeatability_px_threshold)
-    rep_s_list = [(rep_s_1 + rep_s_2) / 2
-                  for rep_s_1, rep_s_2 in zip(rep_s_list_1, rep_s_list_2)]
+    # Disable it for pairwise matching
+    if cfg.method_dict['config_common']['num_keypoints'] == -1:
+        rep_s_list = []
+    else:
+        rep_s_list_1 = get_repeatability(
+            kp1_p[np.intersect1d(kp1_p_valid_idx, d1_nonzero_idx)], kp2,
+            cfg.matching_score_and_repeatability_px_threshold)
+        rep_s_list_2 = get_repeatability(
+            kp2_p[np.intersect1d(kp2_p_valid_idx, d2_nonzero_idx)], kp1,
+            cfg.matching_score_and_repeatability_px_threshold)
+        rep_s_list = [(rep_s_1 + rep_s_2) / 2
+                      for rep_s_1, rep_s_2 in zip(rep_s_list_1, rep_s_list_2)]
 
     # Evaluate matching score after initial matching
     geod_d_list = []

--- a/utils/stereo_helper.py
+++ b/utils/stereo_helper.py
@@ -271,14 +271,18 @@ def compute_stereo_metrics_from_E(img1, img2, depth1, depth2, kp1, kp2, calib1,
 
     # Calculate repeatability
     # Thresholds are hardcoded
-    rep_s_list_1 = get_repeatability(
-        kp1_p[np.intersect1d(kp1_p_valid_idx, d1_nonzero_idx)], kp2,
-        cfg.matching_score_and_repeatability_px_threshold)
-    rep_s_list_2 = get_repeatability(
-        kp2_p[np.intersect1d(kp2_p_valid_idx, d2_nonzero_idx)], kp1,
-        cfg.matching_score_and_repeatability_px_threshold)
-    rep_s_list = [(rep_s_1 + rep_s_2) / 2
-                  for rep_s_1, rep_s_2 in zip(rep_s_list_1, rep_s_list_2)]
+    # Disable it for pairwise matching
+    if cfg.method_dict['config_common']['num_keypoints'] == -1:
+        rep_s_list = []
+    else:
+        rep_s_list_1 = get_repeatability(
+            kp1_p[np.intersect1d(kp1_p_valid_idx, d1_nonzero_idx)], kp2,
+            cfg.matching_score_and_repeatability_px_threshold)
+        rep_s_list_2 = get_repeatability(
+            kp2_p[np.intersect1d(kp2_p_valid_idx, d2_nonzero_idx)], kp1,
+            cfg.matching_score_and_repeatability_px_threshold)
+        rep_s_list = [(rep_s_1 + rep_s_2) / 2
+                      for rep_s_1, rep_s_2 in zip(rep_s_list_1, rep_s_list_2)]
 
     # Evaluate matching score after initial matching
     geod_d_list = []

--- a/viz_stereo.py
+++ b/viz_stereo.py
@@ -42,6 +42,11 @@ def main(cfg):
 
     '''
 
+    try:
+        pairwise_keypoints = cfg.method_dict['config_common']['pairwise_keypoints']
+    except:
+        pairwise_keypoints = False
+
     # Files should not be named to prevent (easy) abuse
     # Instead we use 0, ..., cfg.num_viz_stereo_pairs
     viz_folder_hq, viz_folder_lq = get_stereo_viz_folder(cfg)
@@ -114,7 +119,7 @@ def main(cfg):
         inl = ransac_inl_dict[pair]
 
         # Get depth for keypoints
-        if cfg.pairwise_keypoints:
+        if pairwise_keypoints:
             kp1 = keypoints_dict[f'{fn1}-{fn2}']
             kp2 = keypoints_dict[f'{fn2}-{fn1}']
         else:

--- a/viz_stereo.py
+++ b/viz_stereo.py
@@ -114,8 +114,12 @@ def main(cfg):
         inl = ransac_inl_dict[pair]
 
         # Get depth for keypoints
-        kp1 = keypoints_dict[fn1]
-        kp2 = keypoints_dict[fn2]
+        if cfg.pairwise_keypoints:
+            kp1 = keypoints_dict[f'{fn1}-{fn2}']
+            kp2 = keypoints_dict[f'{fn2}-{fn1}']
+        else:
+            kp1 = keypoints_dict[fn1]
+            kp2 = keypoints_dict[fn2]
         # Normalize keypoints
         kp1n = normalize_keypoints(kp1, calc1['K'])
         kp2n = normalize_keypoints(kp2, calc2['K'])
@@ -210,10 +214,10 @@ def main(cfg):
 
         # Plot matches
         # Points are normalized by the focals, which are on average ~670.
-          
+
         max_dist = 5
         if cfg.dataset == 'googleurban':
-            max_dist = 2e-4 
+            max_dist = 2e-4
         if cfg.dataset == 'pragueparks':
            max_dist = 2e-4
         cmap = matplotlib.cm.get_cmap('summer')


### PR DESCRIPTION
Allow pairwise methods like Patch2pix, loftr, etc for the stereo track. 

One needs to save matching pairwise "keypoints" in h5 files in the following format:

```python
src_pts, dst_pts = match_pairwise(img1, img2)
keypoints['img1-img2'] = src_pts
keypoints['img2-img1'] = dst_pts
```

So instead of the default version, where `keypoints.h5` contains N items, one per image, now it should contain 2*N*(N-1) items, two per image pair.

The `matches.h5` file should contain the indexes of the matching keypoints as usual, which in this case means [arange(num_kpts), arange(num_kpts)]

In the  `config.json`, section `config_common` should contain the following entries:

```json
      "num_keypoints": -1,
      "pairwise_keypoints": true
```

This works only for stereo. 